### PR TITLE
main: updating the version properly pin patch version

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ EXAMPLE
 ```hcl
  module "dcos-install" {
   source = "dcos-terraform/dcos-install-remote-exec/null"
-  version = "~> 0.1"
+  version = "~> 0.1.0"
   bootstrap_ip         = "${module.dcos-infrastructure.bootstrap.public_ip}"
   bootstrap_private_ip = "${module.dcos-infrastructure.bootstrap.private_ip}"
   bootstrap_os_user    = "${module.dcos-infrastructure.bootstrap.os_user}"

--- a/main.tf
+++ b/main.tf
@@ -8,7 +8,7 @@
  * ```hcl
  *  module "dcos-install" {
  *   source = "dcos-terraform/dcos-install-remote-exec/null"
- *   version = "~> 0.1"
+ *   version = "~> 0.1.0"
  *   bootstrap_ip         = "${module.dcos-infrastructure.bootstrap.public_ip}"
  *   bootstrap_private_ip = "${module.dcos-infrastructure.bootstrap.private_ip}"
  *   bootstrap_os_user    = "${module.dcos-infrastructure.bootstrap.os_user}"
@@ -62,7 +62,7 @@
 
 module "dcos-bootstrap-install" {
   source  = "dcos-terraform/dcos-install-bootstrap-remote-exec/null"
-  version = "~> 0.1"
+  version = "~> 0.1.0"
 
   bootstrap_ip         = "${var.bootstrap_ip}"
   bootstrap_private_ip = "${var.bootstrap_private_ip}"
@@ -173,7 +173,7 @@ module "dcos-bootstrap-install" {
 
 module "dcos-masters-install" {
   source  = "dcos-terraform/dcos-install-masters-remote-exec/null"
-  version = "~> 0.1"
+  version = "~> 0.1.0"
 
   bootstrap_private_ip = "${var.bootstrap_private_ip}"
   bootstrap_port       = "${var.dcos_bootstrap_port}"
@@ -190,7 +190,7 @@ module "dcos-masters-install" {
 
 module "dcos-private-agents-install" {
   source  = "dcos-terraform/dcos-install-private-agents-remote-exec/null"
-  version = "~> 0.1"
+  version = "~> 0.1.0"
 
   bootstrap_private_ip = "${var.bootstrap_private_ip}"
   bootstrap_port       = "${var.dcos_bootstrap_port}"
@@ -207,7 +207,7 @@ module "dcos-private-agents-install" {
 
 module "dcos-public-agents-install" {
   source  = "dcos-terraform/dcos-install-public-agents-remote-exec/null"
-  version = "~> 0.1"
+  version = "~> 0.1.0"
 
   bootstrap_private_ip = "${var.bootstrap_private_ip}"
   bootstrap_port       = "${var.dcos_bootstrap_port}"


### PR DESCRIPTION
This updates the version behaivor to have ~> 0.1.0: any non-beta version >= 0.1.0 and < 0.2.0

https://www.terraform.io/docs/modules/usage.html#gt-1-2