### PR TITLE
Core Output

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -4,3 +4,8 @@ output "depends" {
   # value       = "${module.dcos-install.depends}"
   value = ""
 }
+
+output "config" {
+  description = "The battle-tested provisioner contents of the output by DC/OS role to perform requried admin actions in behalf of the user as documented in http://mesosphere.com and http://dcos.io"
+  value       = "${module.dcos-core.config}"
+}


### PR DESCRIPTION
Add the created template as an option for output. This will allow users to create the exact same file locally if they wish to support same locally as from bootstrap.

Example:

```
resource "local_file" "vars_file" {
  filename = "../ansible/group_vars/all/dcos.yml"

  content = <<EOF
---
${local.ansible_additional_config}
${module.dcos.config}

EOF
}
```