### PR TITLE
feat: add private key usage

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -185,6 +185,7 @@ module "dcos-install" {
   private_agent_private_ips = var.private_agent_private_ips
   public_agent_private_ips  = var.public_agent_private_ips
   dcos_download_url         = module.dcos-core.download_url
+  bootstrap_ssh_private_key = var.bootstrap_ssh_private_key
   dcos_download_url_checksum = coalesce(
     var.dcos_download_url_checksum,
     module.dcos-core.download_url_checksum,

--- a/main.tf
+++ b/main.tf
@@ -186,10 +186,10 @@ module "dcos-install" {
   public_agent_private_ips  = var.public_agent_private_ips
   dcos_download_url         = module.dcos-core.download_url
   bootstrap_ssh_private_key = var.bootstrap_ssh_private_key
-  dcos_download_url_checksum = coalesce(
+  dcos_download_url_checksum = try(coalesce(
     var.dcos_download_url_checksum,
     module.dcos-core.download_url_checksum,
-  )
+  ), "")
   dcos_version              = module.dcos-core.version
   dcos_image_commit         = var.dcos_image_commit
   dcos_variant              = var.dcos_variant

--- a/main.tf
+++ b/main.tf
@@ -176,7 +176,7 @@ module "dcos-core" {
 
 module "dcos-install" {
   source  = "dcos-terraform/dcos-install-remote-exec-ansible/null"
-  version = "~> 0.3.0"
+  version = "~> 0.3.1"
 
   bootstrap_ip              = var.bootstrap_ip
   bootstrap_private_ip      = var.bootstrap_private_ip

--- a/variables.tf
+++ b/variables.tf
@@ -12,6 +12,11 @@ variable "bootstrap_os_user" {
   description = "The OS user to be used with ssh exec (only for bootstrap)"
 }
 
+variable "bootstrap_ssh_private_key" {
+  default     = ""
+  description = "SSH Private key to be used ( default use SSH_Agent)"
+}
+
 variable "master_ips" {
   type        = list(string)
   description = "List of masterips to SSH to"


### PR DESCRIPTION
adding private key usage. This feature is more meant for testing purpose having terraform generating an SSH key.

For production usage its more secure to use ssh-agent as the private key will be placed on bootstrap node.